### PR TITLE
CI: initial cirrus config

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,0 +1,38 @@
+# The guide to programming cirrus-ci tasks using starlark is found at
+# https://cirrus-ci.org/guide/programming-tasks/
+#
+# In this simple starlark script we simply check conditions for whether
+# a CI run should go ahead. If the conditions are met, then we just
+# return the yaml containing the tasks to be run.
+
+load("cirrus", "env", "fs", "http")
+
+def main(ctx):
+    ######################################################################
+    # Should wheels be built?
+    # Only test on the numpy/numpy repository
+    ######################################################################
+
+    if env.get("CIRRUS_REPO_FULL_NAME") != "andyfaff/numpy":
+        return []
+
+    # if env.get("CIRRUS_CRON", "") == "nightly":
+    #     return fs.read("ci/cirrus_wheels.yml")
+
+    # Obtain commit message for the event. Unfortunately CIRRUS_CHANGE_MESSAGE
+    # only contains the actual commit message on a non-PR trigger event.
+    # For a PR event it contains the PR title and description.
+    SHA = env.get("CIRRUS_CHANGE_IN_REPO")
+    url = "https://api.github.com/repos/scipy/scipy/git/commits/" + SHA
+    dct = http.get(url).json()
+    # if "[wheel build]" in dct["message"]:
+    #     return fs.read("ci/cirrus_wheels.yml")
+
+    if "[skip cirrus]" in dct["message"] or "[skip ci]" in dct["message"]:
+        return []
+
+    config =  fs.read("tools/ci/cirrus_general.yml")
+
+    # add extra jobs to the cirrus run by += adding to config
+
+    return config

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -13,7 +13,7 @@ def main(ctx):
     # Only test on the numpy/numpy repository
     ######################################################################
 
-    if env.get("CIRRUS_REPO_FULL_NAME") != "andyfaff/numpy":
+    if env.get("CIRRUS_REPO_FULL_NAME") != "numpy/numpy":
         return []
 
     # if env.get("CIRRUS_CRON", "") == "nightly":

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -1,0 +1,88 @@
+build_and_store_wheels: &BUILD_AND_STORE_WHEELS
+  install_cibuildwheel_script:
+    - python -m pip install cibuildwheel==2.11.2
+  cibuildwheel_script:
+    - cibuildwheel
+  wheels_artifacts:
+    path: "wheelhouse/*"
+
+
+######################################################################
+# Build linux_aarch64 natively
+######################################################################
+
+cirrus_wheels_linux_aarch64_task:
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder-arm64
+    architecture: arm64
+    platform: linux
+    cpu: 4
+    memory: 8G
+  matrix:
+    # build in a matrix because building and testing all four wheels in a
+    # single task takes longer than 60 mins (the default time limit for a
+    # cirrus-ci task).
+    - env:
+        CIBW_BUILD: cp38-*
+        EXPECT_CPU_FEATURES: NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM
+    - env:
+        CIBW_BUILD: cp39-* cp310-*
+    - env:
+        CIBW_BUILD: cp311-*
+
+  build_script: |
+    apt install -y python3-venv python-is-python3 gfortran libatlas-base-dev libgfortran5 eatmydata
+    git fetch origin
+    ./tools/travis-before-install.sh
+    which python
+    echo $CIRRUS_CHANGE_MESSAGE
+  <<: *BUILD_AND_STORE_WHEELS
+
+
+######################################################################
+# Upload all wheels
+######################################################################
+
+cirrus_wheels_upload_task:
+  # Artifacts don't seem to be persistent from task to task.
+  # Rather than upload wheels at the end of each cibuildwheel run we do a
+  # final upload here. This is because a run may be on different OS for
+  # which bash, etc, may not be present.
+  depends_on:
+    - cirrus_wheels_linux_aarch64
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder
+    platform: linux
+
+#  env:
+#    # created as SCIPY_STAGING_UPLOAD_TOKEN_CIRRUS and SCIPY_NIGHTLY_UPLOAD_TOKEN_CIRRUS
+#    SCIPY_STAGING_UPLOAD_TOKEN: ENCRYPTED[]
+#    SCIPY_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[]
+
+  upload_script: |
+    apt-get install -y python3-venv python-is-python3 curl
+    export IS_SCHEDULE_DISPATCH="false"
+    export IS_PUSH="false"
+
+    # cron job
+    if [[ "$CIRRUS_CRON" == "nightly" ]]; then
+      export IS_SCHEDULE_DISPATCH="true"
+    fi
+
+    # If it's a push event to a maintenance branch, and the commit message contains
+    # '[wheel build]' then upload to staging
+    COMMIT_MSG=$(git log --no-merges -1)
+    if [[ "$COMMIT_MSG" == *"[wheel build]"* ]] && [[ $CIRRUS_BRANCH == maintenance* ]]; then
+          export IS_PUSH="true"
+    fi
+    
+    # The name of the zip file is derived from the `wheels_artifact` line.
+    # If you change the artifact line to `myfile_artifact` then it would be
+    # called myfile.zip
+    
+    curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
+    unzip wheels.zip
+    
+    # TODO upload wheels  

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -58,9 +58,9 @@ cirrus_wheels_upload_task:
     image: family/docker-builder
     platform: linux
 
-#  env:
-#    NUMPY_STAGING_UPLOAD_TOKEN: ENCRYPTED[]
-#    NUMPY_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[]
+  env:
+    NUMPY_STAGING_UPLOAD_TOKEN: ENCRYPTED[!5a69522ae0c2af9edb2bc1cdfeaca6292fb3666d9ecd82dca0615921834a6ce3b702352835d8bde4ea2a9ed5ef8424ac!]
+    NUMPY_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[!196422e6c3419a3b1d79815e1026094a215cb0f346fe34ed0f9d3ca1c19339df7398d04556491b1e0420fc1fe3713289!]
 
   upload_script: |
     apt-get install -y python3-venv python-is-python3 curl

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -57,9 +57,8 @@ cirrus_wheels_upload_task:
     platform: linux
 
 #  env:
-#    # created as SCIPY_STAGING_UPLOAD_TOKEN_CIRRUS and SCIPY_NIGHTLY_UPLOAD_TOKEN_CIRRUS
-#    SCIPY_STAGING_UPLOAD_TOKEN: ENCRYPTED[]
-#    SCIPY_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[]
+#    NUMPY_STAGING_UPLOAD_TOKEN: ENCRYPTED[]
+#    NUMPY_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[]
 
   upload_script: |
     apt-get install -y python3-venv python-is-python3 curl
@@ -71,13 +70,10 @@ cirrus_wheels_upload_task:
       export IS_SCHEDULE_DISPATCH="true"
     fi
 
-    # If it's a push event to a maintenance branch, and the commit message contains
-    # '[wheel build]' then upload to staging
-    COMMIT_MSG=$(git log --no-merges -1)
-    if [[ "$COMMIT_MSG" == *"[wheel build]"* ]] && [[ $CIRRUS_BRANCH == maintenance* ]]; then
-          export IS_PUSH="true"
+    if [[ "$CIRRUS_TAG" == "v*" ]]; then
+      export IS_PUSH="true"    
     fi
-    
+
     # The name of the zip file is derived from the `wheels_artifact` line.
     # If you change the artifact line to `myfile_artifact` then it would be
     # called myfile.zip
@@ -86,3 +82,6 @@ cirrus_wheels_upload_task:
     unzip wheels.zip
     
     # TODO upload wheels  
+    source ./tools/wheels/upload_wheels.sh
+    set_upload_vars
+    upload_wheels # Will be skipped if not a push/tag/scheduled build

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -27,7 +27,9 @@ cirrus_wheels_linux_aarch64_task:
         CIBW_BUILD: cp38-*
         EXPECT_CPU_FEATURES: NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM
     - env:
-        CIBW_BUILD: cp39-* cp310-*
+        CIBW_BUILD: cp39-*
+    - env:
+        CIBW_BUILD: cp310-*
     - env:
         CIBW_BUILD: cp311-*
 

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -83,7 +83,6 @@ cirrus_wheels_upload_task:
     curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
     unzip wheels.zip
     
-    # TODO upload wheels  
     source ./tools/wheels/upload_wheels.sh
     set_upload_vars
     upload_wheels # Will be skipped if not a push/tag/scheduled build


### PR DESCRIPTION
@charris @mattip here is WIP for a cirrus-ci setup to replace the cp38 to cp311 build the wheels and test them on `manylinux2014_aarch64`.

The wheels get built and uploaded as artifacts to the cirrus ci run, e.g. https://cirrus-ci.com/task/4653593037897728.
There needs to be work on exactly when you want this to be triggered. e.g. cron, every push, every PR, only on a tag, etc.
It's also not clear whether `tools/travis-test.sh` needs to be run or not? cibuildwheel already runs the test suite, but travis-test 